### PR TITLE
Make mobs spawn offscreen

### DIFF
--- a/Demo's/celeryman/MobPath.gd
+++ b/Demo's/celeryman/MobPath.gd
@@ -1,18 +1,20 @@
 extends Path2D
 
-var SIZE = 500
-var ORIGIN_X = 1920/2
-var ORIGIN_Y = 1080/2
-var NUM_POINTS = 32
+var WIDTH = 1920
+var HEIGHT = 1080
+var ORIGIN_X = WIDTH/2
+var ORIGIN_Y = HEIGHT/2
+var PAD = 50
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	curve = Curve2D.new()
-	for i in NUM_POINTS:
-		curve.add_point(Vector2(0, -SIZE).rotated((i / float(NUM_POINTS)) * TAU) + Vector2(ORIGIN_X, ORIGIN_Y))
-
-	# End the circle.
-	curve.add_point(Vector2(0, -SIZE) + Vector2(ORIGIN_X, ORIGIN_Y))
+	
+	curve.add_point(Vector2(-PAD		, -PAD		)) # Left-Top
+	curve.add_point(Vector2(WIDTH+PAD	, -PAD		)) # Right-Top
+	curve.add_point(Vector2(WIDTH+PAD	, HEIGHT+PAD)) # Right-Bottom
+	curve.add_point(Vector2(-PAD		, HEIGHT+PAD)) # Left-Bottom
+	curve.add_point(Vector2(-PAD		, -PAD		)) # Left-Top
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.

--- a/Demo's/celeryman/main.gd
+++ b/Demo's/celeryman/main.gd
@@ -38,6 +38,19 @@ func _on_start_timer_timeout():
 	$MobTimer.start()
 	$ScoreTimer.start()
 
+
+var CENTER = Vector2(1920/2, 1080/2)
+func calc_direction_to_look_at(target, origin):
+	var dx = target.x - origin.x
+	var dy = target.y - origin.y
+	var direction = atan(dy/dx)
+	# atan doesn't know wether the angle needs to point left or right
+	# so the angle might need to be inverted, depending on dx
+	if dx < 0:
+		direction +=  PI
+	return direction
+
+
 func _on_mob_timer_timeout():
 	# Create a new instance of the Mob scene.
 	var mob = mob_scene.instantiate()
@@ -49,16 +62,14 @@ func _on_mob_timer_timeout():
 	var mob_spawn_location = get_node("MobPath/MobSpawnLocation")
 	mob_spawn_location.progress_ratio = randf()
 
-	# Set the mob's direction perpendicular to the path direction.
-	var direction = mob_spawn_location.rotation + PI / 2
-
 	# Set the mob's position to a random location.
 	mob.position = mob_spawn_location.position
+	
+	# Set the mob's direction to look at center
+	var direction = calc_direction_to_look_at(CENTER, mob.position)
 
 	# Add some randomness to the direction. -> I tried to make them point to the middle
-	direction += randf_range(-PI/4,PI/4)
-	
-	
+	direction += randf_range(-PI/8,PI/8)
 	mob.rotation = direction
 
 	# Choose the velocity for the mob.


### PR DESCRIPTION
The distance they are spawned at from the screen borders is controlled by the PAD constant.

Also had to rewrite the code responsible for setting the rotation of the mob as path can no longer be used for this purpose.

Lastly, changed the random component of the rotation to PI/8, instead of PI/4. Because the old range was too big when spawning so far off the screen.